### PR TITLE
Add rule to pin messages from channels and notify all members.

### DIFF
--- a/bot/dialogs/rules/__init__.py
+++ b/bot/dialogs/rules/__init__.py
@@ -1,3 +1,3 @@
-__all__ = ["main", "urlfilter", "bad_words", "non_latin_filter", "market"]
+__all__ = ["main", "urlfilter", "bad_words", "non_latin_filter", "market", "channel_pin"]
 
 from dialogs.rules import *

--- a/bot/dialogs/rules/channel_pin.py
+++ b/bot/dialogs/rules/channel_pin.py
@@ -1,0 +1,12 @@
+def init(update, context):
+    """
+    'channel-pin' pin a message coming from selected channels and notify all members
+    """
+    if update.message.sender_chat.type == 'channel':
+        # unpin message
+        context.bot.unpin_chat_message(chat_id=update.message.chat_id,
+                                       message_id=update.message.message_id)
+        # pin message + notify all members
+        context.bot.pin_chat_message(chat_id=update.message.chat_id, message_id=update.message.message_id,
+                                     disable_notification=False)
+

--- a/bot/dialogs/rules/main.py
+++ b/bot/dialogs/rules/main.py
@@ -1,8 +1,10 @@
-from . import urlfilter, bad_words, non_latin_filter, market
+from . import urlfilter, bad_words, non_latin_filter, market, channel_pin
 def init(update, context):
     market.init(update, context)
     urlfilter.init(update, context)
     bad_words.init(update, context)
     non_latin_filter.init(update, context)
+    channel_pin.init(update, context)
+
     
     


### PR DESCRIPTION
This commit changes (slightly) the normal behaviour of the link
between channel and group.
This function unpin the message coming from the channel and repin it
with the addition of notifying all members.

Changes:
  modified:   bot/dialogs/rules/__init__.py
  new file:   bot/dialogs/rules/channel_pin.py
  modified:   bot/dialogs/rules/main.py