### PR TITLE
Add commands /autoban and /autokick

### DIFF
--- a/bot/commands/admin/__init__.py
+++ b/bot/commands/admin/__init__.py
@@ -1,3 +1,4 @@
-__all__ = ["kick", "night", "mute", "unmute", "ban", "unban", "pin", "say", "annuncio", "check", "nuke", "leave", "delete", "slow"]
+__all__ = ["kick", "night", "mute", "unmute", "ban", "unban", "pin", "say",
+           "annuncio", "check", "nuke", "leave", "delete", "slow", "autoban", "autokick"]
 
 from commands.admin import *

--- a/bot/commands/admin/autoban.py
+++ b/bot/commands/admin/autoban.py
@@ -1,0 +1,41 @@
+from utils import decorator
+from telegram.error import TelegramError
+
+
+@decorator.general_admin
+@decorator.cancellacomandi
+def init(update, context):
+    """
+    This command is executed sending the command:
+        /autoban reason
+    
+    where 'reason' is a message to explain to the user the reason of the ban
+
+    The command must be used in reply to the user's message. The bot sends a message
+    in the chat to the user providing the 'reason'. After 60 seconds the user is banned.
+    """
+    # decode command
+    reason = update.message.text.replace('/autoban ', '').strip()
+    # get username
+    name = "@" + update.message.reply_to_message.from_user.username \
+        if update.message.reply_to_message.from_user.username is not None \
+        else update.message.reply_to_message.from_user.name
+
+    # set and send message to the user
+    msg = f"{name}, sarai bannato dal gruppo fra 60 secondi per questo motivo:\n\n{reason}"
+    context.bot.send_message(chat_id=update.message.chat_id,
+                             text=msg,
+                             reply_to_message_id=update.message.reply_to_message.message_id)
+
+    # set delayed action
+    def delayed_ban(context, update=update):
+        try:
+            context.bot.ban_chat_member(chat_id=update.message.chat.id,
+                                        user_id=update.message.reply_to_message.from_user.id)
+        except TelegramError:
+            print("an error occurred [AUTOBAN] function")
+            update.message.send_message(chat_id=update.message.chat_id, text="Error during autoban operation")
+
+    # schedule action
+    seconds = 60
+    context.job_queue.run_once(delayed_ban, seconds)

--- a/bot/commands/admin/autokick.py
+++ b/bot/commands/admin/autokick.py
@@ -1,0 +1,42 @@
+from utils import decorator
+from telegram.error import TelegramError
+
+
+@decorator.general_admin
+@decorator.cancellacomandi
+def init(update, context):
+    """
+    This command is executed sending the command:
+        /autokick reason
+    
+    where 'reason' is a message to explain to the user the reason of the kick
+
+    The command must be used in reply to the user's message. The bot sends a message
+    in the chat to the user providing the 'reason'. After 60 seconds the user is kicked.
+    """
+    # decode command
+    reason = update.message.text.replace('/autokick ', '').strip()
+    # get username
+    name = "@" + update.message.reply_to_message.from_user.username \
+        if update.message.reply_to_message.from_user.username is not None \
+        else update.message.reply_to_message.from_user.name
+
+    # set and send message to the user
+    msg = f"{name}, sarai kickato dal gruppo fra 60 secondi per questo motivo:\n\n{reason}"
+    context.bot.send_message(chat_id=update.message.chat_id,
+                             text=msg,
+                             reply_to_message_id=update.message.reply_to_message.message_id)
+
+    # set delayed action
+    def delayed_ban(context, update=update):
+        try:
+            user_id = update.message.reply_to_message.from_user.id
+            context.bot.ban_chat_member(chat_id=update.message.chat.id, user_id=user_id)
+            context.bot.unban_chat_member(chat_id=update.message.chat.id, user_id=user_id)
+        except TelegramError:
+            print("an error occurred [AUTOKICK] function")
+            update.message.send_message(chat_id=update.message.chat_id, text="Error during autokick operation")
+
+    # schedule action
+    seconds = 60
+    context.job_queue.run_once(delayed_ban, seconds)

--- a/bot/commands/index.py
+++ b/bot/commands/index.py
@@ -30,5 +30,7 @@ def admin_commands(dp):
     function(CMH(["notte", "night", "silenzio", "silence"], commands.admin.night.init))
     function(CMH("kick", commands.admin.kick.init))
     function(CMH("slow", commands.admin.slow.init))
+    function(CMH("autoban", commands.admin.autoban.init))
+    function(CMH("autokick", commands.admin.autokick.init))
     
     


### PR DESCRIPTION
The commands are executed sendingin in the chat:
    /autokick reason
    /autoban reason

where 'reason' is a message to explain to the user the reason of the kick/ban.

The command must be used in reply to the user's message. The bot send a message in the chat to the user providing the 'reason'. After 60 seconds the user is kicked/banned.

Changes:
    modified:   commands/admin/__init__.py
    new file:   commands/admin/autoban.py
    new file:   commands/admin/autokick.py
    modified:   commands/index.py